### PR TITLE
Fix patch issue in resource apply

### DIFF
--- a/pkg/handler/chart_apply.go
+++ b/pkg/handler/chart_apply.go
@@ -76,7 +76,13 @@ func ApplyResource(f cmdutil.Factory, model unstructured.Unstructured, skipCRds 
 		p3 := struct {
 			Patch jsonpatch.Patch `json:"patch"`
 		}{}
-		err = meta_util.DecodeObject(model.Object, &p3)
+
+		data, err := model.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(data, &p3)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Masudur Rahman <masud@appscode.com>

```
6 error(s) decoding:
	
	* 'patch[0][op]': source data must be an array or slice, got string
	* 'patch[0][path]': source data must be an array or slice, got string
	* 'patch[0][value]': source data must be an array or slice, got string
	* 'patch[1][op]': source data must be an array or slice, got string
	* 'patch[1][path]': source data must be an array or slice, got string
	* 'patch[1][value]': source data must be an array or slice, got int64
```
