### PR TITLE
Prepare for release v0.5.0

### DIFF
--- a/aws.sh
+++ b/aws.sh
@@ -18,7 +18,7 @@ echo
 basename "$0"
 echo "---------------"
 
-CHART_VERSION=${CHART_VERSION:-v0.15.0}
+CHART_VERSION=${CHART_VERSION:-v0.16.0}
 
 go run cmd/fuse-chart/*.go \
     --sample-dir=$HOME/go/src/go.bytebuilders.dev/ui-samples/aws/documentdb \

--- a/capi.sh
+++ b/capi.sh
@@ -18,7 +18,7 @@ echo
 basename "$0"
 echo "---------------"
 
-CHART_VERSION=${CHART_VERSION:-v0.15.0}
+CHART_VERSION=${CHART_VERSION:-v0.16.0}
 
 go run cmd/fuse-chart/*.go \
     --sample-dir=$HOME/go/src/go.bytebuilders.dev/ui-samples/featuresets/capi-core \

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.32.2
 	kmodules.xyz/client-go v0.32.1
-	kmodules.xyz/resource-metadata v0.27.0
+	kmodules.xyz/resource-metadata v0.28.0
 	kmodules.xyz/sets v0.29.0
 	kubepack.dev/chart-doc-gen v0.5.0
 	kubepack.dev/kubepack v0.29.1
@@ -234,7 +234,7 @@ require (
 	go.appscode.dev/alerts v0.2.1-0.20250217100836-596fabefb762 // indirect
 	go.bytebuilders.dev/catalog v0.0.13 // indirect
 	go.bytebuilders.dev/resource-model v0.2.0 // indirect
-	go.bytebuilders.dev/ui-wizards v0.15.0 // indirect
+	go.bytebuilders.dev/ui-wizards v0.16.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -792,8 +792,8 @@ go.bytebuilders.dev/installer v0.1.1-0.20250321095236-0efddb6628ad h1:8hRdI1lZia
 go.bytebuilders.dev/installer v0.1.1-0.20250321095236-0efddb6628ad/go.mod h1:fpRbjbyKc+Y98yH7UJHWY1p5W0WwB6lSy7W8QSPoMwk=
 go.bytebuilders.dev/resource-model v0.2.0 h1:ExD1qRjcFjy1FirH/LOhlToNCrzeFd8wspxoTQzUJUQ=
 go.bytebuilders.dev/resource-model v0.2.0/go.mod h1:+/6wCmfEDcwOdi+EfzOjj8hNqyzIr6HwSqMOuC3JLUk=
-go.bytebuilders.dev/ui-wizards v0.15.0 h1:5g2nzPXw8GQGoI8UAV2VM1cIyuZ8NFQNFdlN8O97188=
-go.bytebuilders.dev/ui-wizards v0.15.0/go.mod h1:q9oMBvLVmUg3VwXgo8vZsRNokPi8Rj0Og0wZH6JHXJU=
+go.bytebuilders.dev/ui-wizards v0.16.0 h1:zFKq+99iG7uz73Bl1eqJWOJ+Cmui7pVEmnCo3vMomBc=
+go.bytebuilders.dev/ui-wizards v0.16.0/go.mod h1:q9oMBvLVmUg3VwXgo8vZsRNokPi8Rj0Og0wZH6JHXJU=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -1208,8 +1208,8 @@ kmodules.xyz/offshoot-api v0.32.0 h1:gogc5scSZe2JoXtZof72UGRl3Tit0kFaFRMkLLT1D8o
 kmodules.xyz/offshoot-api v0.32.0/go.mod h1:tled7OxYZ3SkUJcrVFVVYyd+zXjsRSEm1R6Q3k4gcx0=
 kmodules.xyz/prober v0.29.0 h1:Ex7m4F9rH7uWNNJlLgP63ROOM+nUATJkC2L5OQ7nwMg=
 kmodules.xyz/prober v0.29.0/go.mod h1:UtK+HKyI1lFLEKX+HFLyOCVju6TO93zv3kwGpzqmKOo=
-kmodules.xyz/resource-metadata v0.27.0 h1:aOzDg5ckcVwp9DYE6UpZb7UGWnqI2XHP6bVJwFfzeUc=
-kmodules.xyz/resource-metadata v0.27.0/go.mod h1:i5dUbGT7jMjDn9ShQ4AAc48JDmqeORigpYEMqeKsx0Y=
+kmodules.xyz/resource-metadata v0.28.0 h1:ifshTakMBnN+ctlJOrNOIU6yaouEhkQAPUrgbEusH44=
+kmodules.xyz/resource-metadata v0.28.0/go.mod h1:i5dUbGT7jMjDn9ShQ4AAc48JDmqeORigpYEMqeKsx0Y=
 kmodules.xyz/resource-metrics v0.30.6 h1:y+26VJ3oJ6FtE+f/sc9HfMAfaySZA+fIytRJ14YtxDo=
 kmodules.xyz/resource-metrics v0.30.6/go.mod h1:SL7hGoKCUOTOEQXVEkryREwlVkujM8jKPVEPUklZ3JY=
 kmodules.xyz/schema-checker v0.4.2 h1:tAbxEtM759GxDM/3sQi/+OKKwUsEF+Ih4KReV3Eb/Xw=

--- a/kubedb.sh
+++ b/kubedb.sh
@@ -18,7 +18,7 @@ echo
 basename "$0"
 echo "---------------"
 
-CHART_VERSION=${CHART_VERSION:-v0.15.0}
+CHART_VERSION=${CHART_VERSION:-v0.16.0}
 
 go run cmd/gen-simple-editor/main.go --all --skipExisting=false \
     --chart-version=$CHART_VERSION

--- a/kubestash.sh
+++ b/kubestash.sh
@@ -18,7 +18,7 @@ echo
 basename "$0"
 echo "---------------"
 
-CHART_VERSION=${CHART_VERSION:-v0.15.0}
+CHART_VERSION=${CHART_VERSION:-v0.16.0}
 
 go run cmd/fuse-chart/*.go \
     --sample-dir=$HOME/go/src/go.bytebuilders.dev/ui-samples/kubestash/backupstorage/s3 \

--- a/ocm.sh
+++ b/ocm.sh
@@ -18,7 +18,7 @@ echo
 basename "$0"
 echo "---------------"
 
-CHART_VERSION=${CHART_VERSION:-v0.15.0}
+CHART_VERSION=${CHART_VERSION:-v0.16.0}
 
 go run cmd/fuse-chart/*.go \
     --sample-dir=$HOME/go/src/go.bytebuilders.dev/ui-samples/featuresets/ocm-hub \

--- a/opscenter.sh
+++ b/opscenter.sh
@@ -18,7 +18,7 @@ echo
 basename "$0"
 echo "---------------"
 
-CHART_VERSION=${CHART_VERSION:-v0.15.0}
+CHART_VERSION=${CHART_VERSION:-v0.16.0}
 
 go run cmd/fuse-chart/*.go \
     --sample-dir=$HOME/go/src/go.bytebuilders.dev/ui-samples/featuresets/opscenter-core \

--- a/stash.sh
+++ b/stash.sh
@@ -18,7 +18,7 @@ echo
 basename "$0"
 echo "---------------"
 
-CHART_VERSION=${CHART_VERSION:-v0.15.0}
+CHART_VERSION=${CHART_VERSION:-v0.16.0}
 
 go run cmd/fuse-chart/*.go \
     --sample-dir=$HOME/go/src/go.bytebuilders.dev/ui-samples/repository/custom \

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
@@ -35,5 +35,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
@@ -35,5 +35,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addondeploymentconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addondeploymentconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addontemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addontemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/clustermanagementaddons.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/clustermanagementaddons.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/managedclusteraddons.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/managedclusteraddons.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.kubestash.com/v1alpha1/addons.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.kubestash.com/v1alpha1/addons.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.kubestash.com/v1alpha1/functions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/addons.kubestash.com/v1alpha1/functions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositeresourcedefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositeresourcedefinitions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositionrevisions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositionrevisions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1/compositions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1alpha1/environmentconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.crossplane.io/v1alpha1/environmentconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
@@ -22,7 +22,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps.k8s.appscode.com/v1/petsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps.k8s.appscode.com/v1/petsets.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps.k8s.appscode.com/v1/placementpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps.k8s.appscode.com/v1/placementpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/daemonsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/daemonsets.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/deployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/deployments.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/replicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/replicasets.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/statefulsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/apps/v1/statefulsets.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mariadbarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mariadbarchivers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mongodbarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mongodbarchivers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mssqlserverarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mssqlserverarchivers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mysqlarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mysqlarchivers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/postgresarchivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/archiver.kubedb.com/v1alpha1/postgresarchivers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/accounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/accounts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/users.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/users.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.open-cluster-management.io/v1beta1/managedserviceaccounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authentication.open-cluster-management.io/v1beta1/managedserviceaccounts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.azure.kubedb.com/v1alpha1/roleassignments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.azure.kubedb.com/v1alpha1/roleassignments.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterrolebindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterroles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclustersetrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclustersetrolebindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/cassandraautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/cassandraautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/clickhouseautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/clickhouseautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/druidautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/druidautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/ferretdbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/ferretdbautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/kafkaautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/kafkaautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mssqlserverautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mssqlserverautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgpoolautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgpoolautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/rabbitmqautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/rabbitmqautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/singlestoreautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/singlestoreautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/solrautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/solrautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/zookeeperautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/zookeeperautoscalers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/providerregistrations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/providerregistrations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/resourcegroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/resourcegroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/subscriptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1alpha1/subscriptions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/cronjobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/cronjobs.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/jobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1/jobs.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/rediscaches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/rediscaches.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterpriseclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterpriseclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterprisedatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterprisedatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisfirewallrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redislinkedservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redislinkedservers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/clickhousebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/clickhousebindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/druidbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/druidbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/elasticsearchbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/elasticsearchbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/ferretdbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/ferretdbbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/kafkabindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/kafkabindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mariadbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mariadbbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/memcachedbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/memcachedbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mongodbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mongodbbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mssqlserverbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mssqlserverbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mysqlbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/mysqlbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/perconaxtradbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/perconaxtradbbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgbouncerbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgbouncerbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgpoolbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgpoolbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/postgresbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/postgresbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/proxysqlbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/proxysqlbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/rabbitmqbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/rabbitmqbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/redisbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/redisbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/singlestorebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/singlestorebindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/solrbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/solrbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/zookeeperbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.appscode.com/v1alpha1/zookeeperbindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/cassandraversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/cassandraversions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/clickhouseversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/clickhouseversions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/druidversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/druidversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/ferretdbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/ferretdbversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaconnectorversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaconnectorversions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mssqlserverversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mssqlserverversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgpoolversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgpoolversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/rabbitmqversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/rabbitmqversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/schemaregistryversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/schemaregistryversions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/singlestoreversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/singlestoreversions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/solrversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/solrversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/zookeeperversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubedb.com/v1alpha1/zookeeperversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/elasticsearchbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/elasticsearchbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/kafkabindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/kafkabindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mariadbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mariadbbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/memcachedbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/memcachedbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mongodbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mongodbbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mysqlbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mysqlbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/perconaxtradbbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/perconaxtradbbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/pgbouncerbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/pgbouncerbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/postgresbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/postgresbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/proxysqlbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/proxysqlbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/redisbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/redisbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
@@ -35,5 +35,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
@@ -35,5 +35,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
@@ -35,5 +35,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
@@ -35,5 +35,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
@@ -22,7 +22,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: chartsxhelmdev-clusterchartpreset-editor-options
@@ -30,4 +30,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1/managedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1/managedclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/addonplacementscores.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/addonplacementscores.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/clusterclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/clusterclaims.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placementdecisions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placementdecisions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placements.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placements.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersetbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersetbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/firewalls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/firewalls.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networkpeerings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networkpeerings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networks.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gateway.open-cluster-management.io/v1alpha1/clustergatewayconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/config.gateway.open-cluster-management.io/v1alpha1/clustergatewayconfigurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/rosacontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/rosacontrolplanes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/projects.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/projects.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupbatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupbatches.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupblueprints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupblueprints.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupconfigurations.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: corekubestashcom-backupconfiguration-editor-options
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupsessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupsessions.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: corekubestashcom-backupsession-editor-options
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverificationsession.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverificationsession.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverifier.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverifier.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/hooktemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/hooktemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/restoresessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core.kubestash.com/v1alpha1/restoresessions.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: corekubestashcom-restoresession-editor-options
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/bindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/bindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/componentstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/componentstatuses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/configmaps.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/configmaps.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/endpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/endpoints.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/events.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/limitranges.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/limitranges.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/namespaces.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/namespaces.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/nodes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/nodes.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/persistentvolumes.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/pods.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/pods.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podstatusresults.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/podstatusresults.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/rangeallocations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/rangeallocations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/replicationcontrollers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/replicationcontrollers.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequotas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/resourcequotas.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/secrets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/secrets.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/serviceaccounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/serviceaccounts.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/services.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/core/v1/services.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/accounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/accounts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandraclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandraclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandradatacenters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandradatacenters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandrakeyspaces.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandrakeyspaces.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandratables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandratables.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlindatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlindatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlingraphs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlingraphs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongocollections.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongocollections.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongodatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongodatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlcontainers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlcontainers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldedicatedgateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldedicatedgateways.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlfunctions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlfunctions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroleassignments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroleassignments.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroledefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroledefinitions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlstoredprocedures.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlstoredprocedures.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqltriggers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqltriggers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/tables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/tables.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/databases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/servers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/databases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibledatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibledatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/servers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/databases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverdatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/serverkeys.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/serverkeys.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/servers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterinstances.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/globalclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/globalclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/contributorinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/contributorinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/globaltables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/globaltables.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/kinesisstreamingdestinations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/kinesisstreamingdestinations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tableitems.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tableitems.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tablereplicas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tablereplicas.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tables.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tags.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tags.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/routes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/routes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygrouprules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygrouprules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/subnets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/subnets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcendpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcendpoints.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcpeeringconnections.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcpeeringconnections.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/replicationgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/replicationgroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/usergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/usergroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/users.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/users.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domains.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domains.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainsamloptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainsamloptions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/elasticsearch.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/pkiroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/pkiroles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1/events.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/deployments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/deployments.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/scales.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/extensions/v1beta1/scales.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/falco.appscode.com/v1alpha1/falcoevents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/falco.appscode.com/v1alpha1/falcoevents.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/fluxcd.open-cluster-management.io/v1alpha1/fluxcdconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/fluxcd.open-cluster-management.io/v1alpha1/fluxcdconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewayconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewayconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewaypresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewaypresets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/authenticationfilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/authenticationfilters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backends.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backends.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backendtrafficpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backendtrafficpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/clienttrafficpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/clienttrafficpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoypatchpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoypatchpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/ratelimitfilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/ratelimitfilters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/securitypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/securitypolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/gatewayclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/gatewayclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/gateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/gateways.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/grpcroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/grpcroutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/httproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1/httproutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendtlspolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendtlspolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/grpcroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/grpcroutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tcproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tcproutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tlsroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tlsroutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/udproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/udproutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gatewayclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gatewayclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gateways.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/httproutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/httproutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/referencegrants.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/referencegrants.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.open-cluster-management.io/v1alpha1/clustergateways.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.open-cluster-management.io/v1alpha1/clustergateways.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/kafkaroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/kafkaroutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mongodbroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mongodbroutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mysqlroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mysqlroutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/postgresroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/postgresroutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/redisroutes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/redisroutes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2/helmreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2/helmreleases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta2/helmreleases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta2/helmreleases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/iam.aws.kubedb.com/v1alpha1/roles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/iam.aws.kubedb.com/v1alpha1/roles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/clusteridentitys.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/clusteridentitys.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/selfsubjectnamespaceaccessreviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/selfsubjectnamespaceaccessreviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/siteinfos.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/siteinfos.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagepolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagepolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagerepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagerepositories.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imageupdateautomations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imageupdateautomations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclustertemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanetemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepooltemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepooltemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclustertemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanetemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepooltemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepooltemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclustertemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachines.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachinetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachinetemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedcontrolplanes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedcontrolplanes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedmachinepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosaclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosaclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosamachinepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosamachinepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddressclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddressclaims.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddresses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/configurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectors.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/restproxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/restproxies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/schemaregistries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kafka.kubedb.com/v1alpha1/schemaregistries.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.azure.com/v1alpha2/aksnodeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.azure.com/v1alpha2/aksnodeclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.k8s.aws/v1beta1/ec2nodeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.k8s.aws/v1beta1/ec2nodeclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.sh/v1beta1/nodeclaims.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.sh/v1beta1/nodeclaims.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.sh/v1beta1/nodepools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/karpenter.sh/v1beta1/nodepools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/keys.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/keys.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/vaults.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/vaults.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kinesis.aws.kubedb.com/v1alpha1/streams.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kinesis.aws.kubedb.com/v1alpha1/streams.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kms.aws.kubedb.com/v1alpha1/keys.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kms.aws.kubedb.com/v1alpha1/keys.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicebindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexportrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexportrequests.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexports.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexports.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicenamespaces.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicenamespaces.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/clusterbindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/clusterbindings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/elasticsearches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/elasticsearches.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -147,7 +147,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -177,7 +177,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -195,7 +195,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -209,7 +209,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -225,7 +225,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -240,7 +240,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-elasticsearch-editor-options
@@ -248,7 +248,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/kafkas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/kafkas.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -89,7 +89,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -103,7 +103,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -165,7 +165,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -180,7 +180,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-kafka-editor-options
@@ -188,7 +188,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mariadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mariadbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -147,7 +147,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -177,7 +177,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -207,7 +207,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -223,7 +223,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -238,7 +238,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-mariadb-editor-options
@@ -246,7 +246,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/memcacheds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/memcacheds.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -89,7 +89,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -121,7 +121,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -135,7 +135,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -150,7 +150,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: kubedbcom-memcached-editor-options
@@ -158,7 +158,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mongodbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mongodbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -147,7 +147,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -177,7 +177,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -207,7 +207,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -223,7 +223,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -238,7 +238,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-mongodb-editor-options
@@ -246,7 +246,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/mysqls.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -147,7 +147,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -177,7 +177,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -207,7 +207,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -223,7 +223,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -238,7 +238,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-mysql-editor-options
@@ -246,7 +246,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/perconaxtradbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/perconaxtradbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -61,7 +61,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -89,7 +89,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -135,7 +135,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -164,7 +164,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-perconaxtradb-editor-options
@@ -172,7 +172,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/pgbouncers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/pgbouncers.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -61,7 +61,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -91,7 +91,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -107,7 +107,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -122,7 +122,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: kubedbcom-pgbouncer-editor-options
@@ -130,7 +130,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/postgreses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/postgreses.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -147,7 +147,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -177,7 +177,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -207,7 +207,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -223,7 +223,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -238,7 +238,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-postgres-editor-options
@@ -246,7 +246,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/proxysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/proxysqls.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -103,7 +103,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -148,7 +148,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: kubedbcom-proxysql-editor-options
@@ -156,7 +156,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/redises.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/redises.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -147,7 +147,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -177,7 +177,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -207,7 +207,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -223,7 +223,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -238,7 +238,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-redis-editor-options
@@ -246,7 +246,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/redissentinels.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1/redissentinels.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -103,7 +103,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -148,7 +148,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
   variants:
   - name: default

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/cassandras.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/cassandras.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/clickhouses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/clickhouses.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -61,7 +61,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -89,7 +89,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -104,7 +104,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-clickhouse-editor-options
@@ -112,7 +112,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/druids.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/druids.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -59,7 +59,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -89,7 +89,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -103,7 +103,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -134,7 +134,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-druid-editor-options
@@ -142,7 +142,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -59,7 +59,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -89,7 +89,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -103,7 +103,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -135,7 +135,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -164,7 +164,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-elasticsearch-editor-options
@@ -172,7 +172,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/ferretdbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/ferretdbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -59,7 +59,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -89,7 +89,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -134,7 +134,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-ferretdb-editor-options
@@ -142,7 +142,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -44,7 +44,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-kafka-editor-options
@@ -52,7 +52,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -59,7 +59,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -178,7 +178,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-mariadb-editor-options
@@ -186,7 +186,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -61,7 +61,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -91,7 +91,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -120,7 +120,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: kubedbcom-memcached-editor-options
@@ -128,7 +128,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -59,7 +59,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -179,7 +179,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -208,7 +208,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-mongodb-editor-options
@@ -216,7 +216,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mssqlservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mssqlservers.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -179,7 +179,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -208,7 +208,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-mssqlserver-editor-options
@@ -216,7 +216,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -59,7 +59,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -178,7 +178,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-mysql-editor-options
@@ -186,7 +186,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-perconaxtradb-editor-options
@@ -35,7 +35,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: kubedbcom-pgbouncer-editor-options
@@ -35,7 +35,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgpools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/pgpools.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -61,7 +61,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -75,7 +75,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -91,7 +91,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -107,7 +107,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -121,7 +121,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -136,7 +136,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-pgpool-editor-options
@@ -144,7 +144,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -59,7 +59,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -178,7 +178,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-postgres-editor-options
@@ -186,7 +186,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -103,7 +103,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -132,7 +132,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: kubedbcom-proxysql-editor-options
@@ -140,7 +140,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/rabbitmqs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/rabbitmqs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -44,7 +44,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -58,7 +58,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -76,7 +76,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -90,7 +90,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -104,7 +104,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -120,7 +120,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -134,7 +134,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -150,7 +150,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -164,7 +164,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -179,7 +179,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-rabbitmq-editor-options
@@ -187,7 +187,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -59,7 +59,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -105,7 +105,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -149,7 +149,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -178,7 +178,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-redis-editor-options
@@ -186,7 +186,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
   variants:
   - name: default

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/singlestores.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/singlestores.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -147,7 +147,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -177,7 +177,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -207,7 +207,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -223,7 +223,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -238,7 +238,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-singlestore-editor-options
@@ -246,7 +246,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/solrs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/solrs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -119,7 +119,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -133,7 +133,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -147,7 +147,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -163,7 +163,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -177,7 +177,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-edit
         icons:
@@ -193,7 +193,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -208,7 +208,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-solr-editor-options
@@ -216,7 +216,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/zookeepers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubedb.com/v1alpha2/zookeepers.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -43,7 +43,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -73,7 +73,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -87,7 +87,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -101,7 +101,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -117,7 +117,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -131,7 +131,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -145,7 +145,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: true
         flow: standalone-create
         icons:
@@ -161,7 +161,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-create
         icons:
@@ -175,7 +175,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: appscode-charts-oci
-          version: v0.15.0
+          version: v0.16.0
         enforceQuota: false
         flow: standalone-edit
         icons:
@@ -190,7 +190,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: true
     options:
       name: kubedbcom-zookeeper-editor-options
@@ -198,7 +198,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: kubevaultcom-vaultserver-editor-options
@@ -35,7 +35,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
   variants:
   - name: default
     selector:

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1/kustomizations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1/kustomizations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/management.k8s.appscode.com/v1alpha1/projectquotas.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/management.k8s.appscode.com/v1alpha1/projectquotas.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/acls.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/acls.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/snapshots.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/gatewayinfoes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/gatewayinfoes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcecalculators.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcecalculators.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceeditors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceeditors.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcemanifests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcemanifests.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/prometheusagents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/prometheusagents.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/scrapeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/monitoring.coreos.com/v1alpha1/scrapeconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszones.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszones.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszonevirtualnetworklinks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszonevirtualnetworklinks.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/routetables.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/routetables.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/securitygroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/securitygroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetnetworksecuritygroupassociations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetnetworksecuritygroupassociations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetroutetableassociations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetroutetableassociations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworkpeerings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworkpeerings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworks.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.appscode.com/v1alpha1/nodetopologies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.appscode.com/v1alpha1/nodetopologies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1/receivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1/receivers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/alerts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/alerts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/providers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/providers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/offline.licenses.appscode.com/v1alpha1/offlinelicenses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/offline.licenses.appscode.com/v1alpha1/offlinelicenses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.open-cluster-management.io/v1/clustermanagers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.open-cluster-management.io/v1/clustermanagers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.open-cluster-management.io/v1/klusterlets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/operator.open-cluster-management.io/v1/klusterlets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/clickhouseopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/clickhouseopsrequests.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/druidopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/druidopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/ferretdbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/ferretdbopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/kafkaopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/kafkaopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mssqlserveropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mssqlserveropsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgpoolopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgpoolopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/rabbitmqopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/rabbitmqopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/singlestoreopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/singlestoreopsrequests.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/solropsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/solropsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/zookeeperopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubedb.com/v1alpha1/zookeeperopsrequests.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/configurationrevisions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/configurationrevisions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/configurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/configurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/providerrevisions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/providerrevisions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/providers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1/providers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1alpha1/controllerconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1alpha1/controllerconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1beta1/locks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/pkg.crossplane.io/v1beta1/locks.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/evictions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/evictions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyconfigurations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyserviceresolvers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyserviceresolvers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusteractivitystreams.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusteractivitystreams.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterendpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterendpoints.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterinstances.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterroleassociations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterroleassociations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -22,7 +22,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
   variants:
   - name: MariaDB

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbinstanceautomatedbackupsreplications.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbinstanceautomatedbackupsreplications.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbsnapshotcopies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbsnapshotcopies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/globalclusters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/globalclusters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instanceroleassociations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instanceroleassociations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instances.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/optiongroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/optiongroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxydefaulttargetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxydefaulttargetgroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxyendpoints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxyendpoints.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxytargets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxytargets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/snapshots.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/redis.gcp.kubedb.com/v1alpha1/instances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/redis.gcp.kubedb.com/v1alpha1/instances.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasspodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasspodstatuses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets.crossplane.io/v1alpha1/storeconfigs.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secrets.crossplane.io/v1alpha1/storeconfigs.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secretsmanager.aws.kubedb.com/v1alpha1/secrets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/secretsmanager.aws.kubedb.com/v1alpha1/secrets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sns.aws.kubedb.com/v1alpha1/topics.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sns.aws.kubedb.com/v1alpha1/topics.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/gitrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/gitrepositories.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmcharts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmcharts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmrepositories.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databaseiammembers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databaseiammembers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instanceiammembers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instanceiammembers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instances.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabasevulnerabilityassessmentrulebaselines.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabasevulnerabilityassessmentrulebaselines.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlelasticpools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlelasticpools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfailovergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfailovergroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfirewallrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobagents.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobagents.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobcredentials.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobcredentials.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanageddatabases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanageddatabases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstanceactivedirectoryadministrators.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstanceactivedirectoryadministrators.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancefailovergroups.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancefailovergroups.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstances.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancevulnerabilityassessments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancevulnerabilityassessments.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqloutboundfirewallrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqloutboundfirewallrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserverdnsaliases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserverdnsaliases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservermicrosoftsupportauditingpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservermicrosoftsupportauditingpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserversecurityalertpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserversecurityalertpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservertransparentdataencryptions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservertransparentdataencryptions.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservervulnerabilityassessments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservervulnerabilityassessments.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlvirtualnetworkrules.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlvirtualnetworkrules.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databaseinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databaseinstances.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databases.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databases.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sourcerepresentationinstances.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sourcerepresentationinstances.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sslcerts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sslcerts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/users.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/users.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: stashappscodecom-repository-editor-options
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: stashappscodecom-restoresession-editor-options
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/accounts.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/accounts.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/containers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/containers.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/backupstorages.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/backupstorages.yaml
@@ -22,7 +22,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: storagekubestashcom-backupstorage-editor-options
@@ -30,4 +30,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/repositories.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/repositories.yaml
@@ -27,7 +27,7 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false
     options:
       name: storagekubestashcom-repository-editor-options
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/retentionpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/retentionpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/snapshots.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/storage.kubestash.com/v1alpha1/snapshots.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/featuresets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/featuresets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseconnections.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseconnections.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
@@ -27,5 +27,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1/appliedmanifestworks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1/appliedmanifestworks.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1/manifestworks.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1/manifestworks.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1alpha1/manifestworkreplicasets.yaml
+++ b/vendor/kmodules.xyz/resource-metadata/hub/resourceeditors/work.open-cluster-management.io/v1alpha1/manifestworkreplicasets.yaml
@@ -22,5 +22,5 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: appscode-charts-oci
-      version: v0.15.0
+      version: v0.16.0
     enforceQuota: false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1041,7 +1041,7 @@ go.bytebuilders.dev/resource-model/apis/cloud
 go.bytebuilders.dev/resource-model/apis/cloud/v1alpha1
 go.bytebuilders.dev/resource-model/apis/config/v1alpha1
 go.bytebuilders.dev/resource-model/crds
-# go.bytebuilders.dev/ui-wizards v0.15.0
+# go.bytebuilders.dev/ui-wizards v0.16.0
 ## explicit; go 1.22.1
 go.bytebuilders.dev/ui-wizards/apis/wizards
 go.bytebuilders.dev/ui-wizards/apis/wizards/v1alpha1
@@ -2129,7 +2129,7 @@ kmodules.xyz/offshoot-api/api/v2
 # kmodules.xyz/prober v0.29.0
 ## explicit; go 1.21.5
 kmodules.xyz/prober/api/v1
-# kmodules.xyz/resource-metadata v0.27.0
+# kmodules.xyz/resource-metadata v0.28.0
 ## explicit; go 1.23.0
 kmodules.xyz/resource-metadata/apis/meta
 kmodules.xyz/resource-metadata/apis/meta/v1alpha1


### PR DESCRIPTION
ProductLine: ACE
Release: v2025.4.30
Release-tracker: https://github.com/appscode-cloud/CHANGELOG/pull/49
Signed-off-by: 1gtm <1gtm@appscode.com>