### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -3,6 +3,11 @@ name: release-tracker
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -12,9 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Generate LGTM App token
+        id: lgtm-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: appscode-cloud
+          repositories: CHANGELOG
+          permission-pull-requests: write
+
       - name: Update release tracker
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          fetch-depth: 1
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Print version info
         id: semver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Print version info
         id: semver
@@ -48,7 +51,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: stash-cli-binaries
           path: bin


### PR DESCRIPTION
## Summary

Apply the CI hardening pattern from appscode-cloud/installer#1252.

- `release-tracker.yml`: switch to the LGTM GitHub App token (owner `appscode-cloud`, repositories `CHANGELOG`), replacing the legacy `LGTM_GITHUB_TOKEN` PAT. Added `workflow_dispatch` and a concurrency group.
- `release.yml`:
  - `actions/checkout` for the tag-triggered job now uses `fetch-depth: 1` + `fetch-tags: true` so the tag ref resolves without a full clone.
  - `actions/upload-artifact@master` → pinned to commit `6f51ac03…` (`v4.5.0`); floating `@master` refs are unsafe.
- `ci.yml` was already SHA-pinned and token-free.

## Test plan

- [ ] Next merged PR triggers `release-tracker` and the comment lands on the CHANGELOG release tracker.
- [ ] Next tag push triggers `release` and the binaries get uploaded.