### PR TITLE
editor: pass chart values to EditorChartValueManifest

### DIFF
--- a/pkg/editor/chart_template.go
+++ b/pkg/editor/chart_template.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gomodules.xyz/jsonpatch/v3"
-	"helm.sh/helm/v3/pkg/chart"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -173,10 +172,10 @@ func loadEditorModel(kc client.Client, reg repo.IRegistry, chartRef releasesapi.
 		return nil, err
 	}
 
-	return EditorChartValueManifest(kc, &app, opts.Metadata, chrt.Chart)
+	return EditorChartValueManifest(kc, &app, opts.Metadata, chrt.Chart.Values)
 }
 
-func EditorChartValueManifest(kc client.Client, app *driversapi.AppRelease, mt releasesapi.Metadata, chrt *chart.Chart) (*releasesapi.EditorTemplate, error) {
+func EditorChartValueManifest(kc client.Client, app *driversapi.AppRelease, mt releasesapi.Metadata, values map[string]any) (*releasesapi.EditorTemplate, error) {
 	isFeaturesetEditor := hub.IsFeaturesetGR(mt.Resource.GroupResource())
 	chartName := mt.Release.Name
 	if isFeaturesetEditor {
@@ -199,7 +198,7 @@ func EditorChartValueManifest(kc client.Client, app *driversapi.AppRelease, mt r
 	resourceKeys := sets.New[string](app.Spec.ResourceKeys...)
 	formKeys := sets.New[string](app.Spec.FormKeys...)
 
-	_, usesForm := chrt.Values["form"]
+	_, usesForm := values["form"]
 
 	var resources []*unstructured.Unstructured
 	for _, gvk := range app.Spec.Components {
@@ -306,7 +305,7 @@ func EditorChartValueManifest(kc client.Client, app *driversapi.AppRelease, mt r
 		Values: &unstructured.Unstructured{
 			Object: map[string]any{
 				"metadata": map[string]any{
-					"resource": chrt.Values["metadata"].(map[string]any)["resource"],
+					"resource": values["metadata"].(map[string]any)["resource"],
 					"release":  mt.Release,
 				},
 				"resources": resourceMap,


### PR DESCRIPTION
## What

Refactors `pkg/editor/chart_template.go` so the editor model/manifest/resources are reconstructed from a chart's **values map** rather than a full `*chart.Chart`:

- Change exported `EditorChartValueManifest` to accept `values map[string]any` instead of `chrt *chart.Chart`.
- Update `loadEditorModel` to pass `chrt.Chart.Values`.
- Drop the `helm.sh/helm/v3/pkg/chart` import from this path.

`go build ./...` passes; the only caller is updated.

## Why

Building block for the `EditorTemplate` aggregated API (`editor.ui.k8s.appscode.com`), which reconstructs an installation's editor view from values.

## Related

- kmodules/resource-metadata#654, kubeops/ui-server#430, appscode-cloud/b3#1527, kubeops/installer#493