### PR TITLE
fusion: keep only apiVersion, kind and metadata in values.yaml

### DIFF
--- a/pkg/editor/chart_template.go
+++ b/pkg/editor/chart_template.go
@@ -172,7 +172,7 @@ func loadEditorModel(kc client.Client, reg repo.IRegistry, chartRef releasesapi.
 		return nil, err
 	}
 
-	return EditorChartValueManifest(kc, &app, opts.Metadata, chrt.Chart.Values)
+	return EditorChartValueManifest(kc, &app, opts.Metadata, chrt.Values)
 }
 
 func EditorChartValueManifest(kc client.Client, app *driversapi.AppRelease, mt releasesapi.Metadata, values map[string]any) (*releasesapi.EditorTemplate, error) {

--- a/pkg/fusion/fusion.go
+++ b/pkg/fusion/fusion.go
@@ -296,7 +296,16 @@ func NewCmdFuse() *cobra.Command {
 				}
 				cp.Object["metadata"] = md
 
-				resourceValues[rsKey] = cp
+				// For fusion charts, keep only the apiVersion, kind and metadata
+				// fields in values.yaml. The rest of the fields are sourced from
+				// the resource's schema defaults.
+				resourceValues[rsKey] = &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": cp.GetAPIVersion(),
+						"kind":       cp.GetKind(),
+						"metadata":   md,
+					},
+				}
 
 				// schema
 				gvr, err := registry.GVR(cp.GetObjectKind().GroupVersionKind())


### PR DESCRIPTION
## What

For fusion charts, trim each resource entry in the generated `values.yaml` so it keeps only the `apiVersion`, `kind` and `metadata` fields.

## Why

The remaining resource fields (e.g. `spec`) are sourced from the resource's schema defaults, so they don't need to be duplicated in the chart's `values.yaml`. This keeps the generated values minimal.

## Notes

- The change only affects what gets stored into `resourceValues` (and hence written to `values.yaml`). The full `cp` object is left intact, since it's reused immediately afterward for schema generation (GVR lookup and the `HelmRelease` → schema conversion, including chart-version resolution).
- `metadata` retains its existing minimal shape (`name`, `namespace`, plus `labels` for `HelmRelease` resources).