### PR TITLE
fusion: keep full HelmRelease object in values.yaml

### DIFF
--- a/pkg/fusion/fusion.go
+++ b/pkg/fusion/fusion.go
@@ -296,15 +296,20 @@ func NewCmdFuse() *cobra.Command {
 				}
 				cp.Object["metadata"] = md
 
-				// For fusion charts, keep only the apiVersion, kind and metadata
-				// fields in values.yaml. The rest of the fields are sourced from
-				// the resource's schema defaults.
-				resourceValues[rsKey] = &unstructured.Unstructured{
-					Object: map[string]any{
-						"apiVersion": cp.GetAPIVersion(),
-						"kind":       cp.GetKind(),
-						"metadata":   md,
-					},
+				if objGK.Group == "helm.toolkit.fluxcd.io" && objGK.Kind == "HelmRelease" {
+					// Keep the full HelmRelease object in values.yaml.
+					resourceValues[rsKey] = cp
+				} else {
+					// For fusion charts, keep only the apiVersion, kind and metadata
+					// fields in values.yaml. The rest of the fields are sourced from
+					// the resource's schema defaults.
+					resourceValues[rsKey] = &unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": cp.GetAPIVersion(),
+							"kind":       cp.GetKind(),
+							"metadata":   md,
+						},
+					}
 				}
 
 				// schema


### PR DESCRIPTION
## What

Skip the fusion `values.yaml` trimming (introduced in #174) for `HelmRelease` resources in the `helm.toolkit.fluxcd.io` API group. For those, the full object is kept in `values.yaml`.

## Why

#174 trims each resource entry to only `apiVersion`, `kind` and `metadata`, on the basis that the remaining fields are sourced from the resource's schema defaults. That assumption does not hold for a `HelmRelease`: its `spec` (chart reference, chart version, values, etc.) is meaningful and cannot be reconstructed from schema defaults, so it must be preserved.

## Behavior

- `helm.toolkit.fluxcd.io/HelmRelease` → full object kept (as before #174).
- All other resources → trimmed to `apiVersion`, `kind`, `metadata` (as in #174).